### PR TITLE
MaskingRingBuffer v1

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![allow(clippy::missing_safety_doc)]
 
 pub mod prelude;
 

--- a/src/masking/mod.rs
+++ b/src/masking/mod.rs
@@ -1,1 +1,82 @@
 mod tests;
+
+pub struct MaskingRingBuffer<S: PartialStorage<Capacity = MaskingCapacity>> {
+    /// The start of the buffer in the storage (`0..CAPACITY`)
+    index: usize,
+    /// The number of items in the buffer (`0..=CAPACITY`)
+    len: usize,
+    /// The underlying storage
+    storage: MaybeUninit<S>,
+}
+
+impl<S: PartialStorage<Capacity = MaskingCapacity>> MaskingRingBuffer<S> {
+    pub fn new(storage: S) -> Self {
+        MaskingRingBuffer {
+            storage: MaybeUninit::new(storage),
+            index: 0,
+            len: 0,
+        }
+    }
+
+    /// Returns whether the ringbuffer is full
+    ///
+    /// A ringbuffer is full when its length equals its capacity. If an item is enqueued
+    /// while the ringbuffer is full [MaskingRingBuffer::enqueue] will dequeue an item to
+    /// make room for the new item. The dequeued item will be returned.
+    pub fn is_full(&self) -> bool {
+        self.len == self.capacity().get()
+    }
+
+    /// Returns true when the ringbuffer is empty
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// The capacity of the underlying storage
+    ///
+    /// This is the maximum number of items that the ringbuffer can hold.
+    pub fn capacity(&self) -> NonZeroUsize {
+        unsafe { Storage::capacity(self.storage.as_ptr()) }.into()
+    }
+
+    /// Add an element to the end of the ringbuffer
+    ///
+    /// If the ringbuffer is full, the first-in element will be removed from the buffer and returned.
+    pub fn enqueue(&mut self, item: S::Item) -> Option<S::Item> {
+        // We need to dequeue if the buffer is full, in which case we return dequeued item
+        let dequeued_item = self.is_full().then(|| self.dequeue()).flatten();
+
+        // Find the offset to put the new item on
+        let mask = unsafe { Storage::capacity(self.storage.as_ptr()) }.mask();
+        let offset = mask & (self.index + self.len);
+
+        // Write the item into the storage at offset
+        // TODO: This could be a provided method on PartialStorage
+        let buffer = unsafe { PartialStorage::raw_ptr_mut(self.storage.as_mut_ptr()) };
+        let ptr = unsafe { (buffer as *mut S::Item).add(offset) };
+        unsafe { *ptr = item };
+
+        self.len += 1;
+
+        dequeued_item
+    }
+
+    /// Remove an element from the start of the ringbuffer
+    pub fn dequeue(&mut self) -> Option<S::Item> {
+        if self.is_empty() {
+            return None;
+        }
+
+        // Get the item from the buffer
+        let offset = self.index.0;
+        let buffer = unsafe { PartialStorage::raw_ptr_mut(self.storage.as_mut_ptr()) };
+        let ptr = unsafe { (buffer as *mut MaybeUninit<S::Item>).add(offset) };
+        let item = unsafe { core::ptr::replace(ptr, MaybeUninit::uninit()).assume_init() };
+
+        let mask = unsafe { Storage::capacity(self.storage.as_ptr()) }.mask();
+        self.index = mask & (self.index + 1);
+        self.len -= 1;
+
+        Some(item)
+    }
+}

--- a/src/masking/mod.rs
+++ b/src/masking/mod.rs
@@ -1,3 +1,9 @@
+use core::mem::MaybeUninit;
+use core::num::NonZeroUsize;
+
+use crate::capacity::MaskingCapacity;
+use crate::storage::{PartialStorage, Storage};
+
 mod tests;
 
 pub struct MaskingRingBuffer<S: PartialStorage<Capacity = MaskingCapacity>> {
@@ -68,9 +74,8 @@ impl<S: PartialStorage<Capacity = MaskingCapacity>> MaskingRingBuffer<S> {
         }
 
         // Get the item from the buffer
-        let offset = self.index.0;
         let buffer = unsafe { PartialStorage::raw_ptr_mut(self.storage.as_mut_ptr()) };
-        let ptr = unsafe { (buffer as *mut MaybeUninit<S::Item>).add(offset) };
+        let ptr = unsafe { (buffer as *mut MaybeUninit<S::Item>).add(self.index) };
         let item = unsafe { core::ptr::replace(ptr, MaybeUninit::uninit()).assume_init() };
 
         let mask = unsafe { Storage::capacity(self.storage.as_ptr()) }.mask();

--- a/src/masking/tests.rs
+++ b/src/masking/tests.rs
@@ -1,1 +1,50 @@
 #![cfg(test)]
+
+use crate::storage::ArrayStorage;
+
+use super::MaskingRingBuffer;
+
+#[test]
+fn enqueue_and_dequeue_once() {
+    let mut buf = MaskingRingBuffer::new(ArrayStorage::<_, _, 4>::default());
+    buf.enqueue(1);
+    assert_eq!(buf.dequeue(), Some(1));
+    assert_eq!(buf.dequeue(), None);
+}
+
+#[test]
+fn fill_buffer_up_before_dequeue() {
+    let mut buf = MaskingRingBuffer::new(ArrayStorage::<_, _, 4>::default());
+
+    assert_eq!(None, buf.enqueue(1));
+    assert_eq!(None, buf.enqueue(2));
+    assert_eq!(None, buf.enqueue(3));
+    assert_eq!(None, buf.enqueue(4));
+
+    assert!(buf.is_full());
+    assert_eq!(Some(1), buf.enqueue(5));
+    assert!(buf.is_full());
+
+    assert_eq!(Some(2), buf.dequeue());
+    assert_eq!(Some(3), buf.dequeue());
+    assert_eq!(Some(4), buf.dequeue());
+    assert_eq!(Some(5), buf.dequeue());
+}
+
+#[test]
+fn wrap_many_times() {
+    let mut buf = MaskingRingBuffer::new(ArrayStorage::<_, _, 4>::default());
+
+    let mut total = 0;
+    for i in 1..=40 {
+        if let Some(n) = buf.enqueue(i) {
+            total += n;
+        }
+    }
+
+    while let Some(n) = buf.dequeue() {
+        total += n;
+    }
+
+    assert_eq!(820, total);
+}


### PR DESCRIPTION
`rustfmt` changes are in a separate commit.

Currently, the only storage type that works is `[MaybeUninit<T>, 4]` because I wanted to focus on the ringbuffer, not implementing `PartialStorage`. I _definitely_ made some mistakes with `unsafe`, so please check carefully and roast appropriately.